### PR TITLE
bug fixes to tempdir creation and turning off  the creation of control RNAs

### DIFF
--- a/guidemaker/cli.py
+++ b/guidemaker/cli.py
@@ -148,7 +148,7 @@ def main(arglist: list = None):
                 os.mkdir(args.tempdir)
                 tempdir = args.tempdir
             else:
-                tempdir = tempfile.mkdtemp
+                tempdir = tempfile.mkdtemp()
         else:
             tempdir = tempfile.mkdtemp(prefix='guidemaker_', dir=args.tempdir)
             pybedtools.helpers.set_tempdir(tempdir)


### PR DESCRIPTION
This Pull Request fixes two errors:

1) when a custom `--tempdir` path was specified an error would occur, specifically "TypeError: expected str, bytes or os.PathLike object, not function"

2) When 0 was passed to `--controls` an error would occur instead of simply not generating control sequences